### PR TITLE
Link libmpdec and libexpat to libpython

### DIFF
--- a/Makefile.envs
+++ b/Makefile.envs
@@ -124,8 +124,6 @@ export MAIN_MODULE_LDFLAGS= $(LDFLAGS_BASE) \
 	-lworkerfs.js \
 	-lwebsocket.js \
 	-leventloop.js \
-	-lmpdec \
-	-lexpat \
 	\
 	--use-preload-plugins \
 	--preload-file $(CPYTHONLIB)@/lib/python$(PYMAJOR).$(PYMINOR) \

--- a/cpython/Makefile
+++ b/cpython/Makefile
@@ -15,15 +15,17 @@ FFIBUILD=$(ROOT)/build/libffi
 LIBFFIREPO=https://github.com/hoodmane/libffi-emscripten
 LIBFFI_TAG=2022-06-23
 
+MAKEFILE_PATCHED=Makefile.patched
+
 all: $(INSTALL)/lib/$(LIB) $(INSTALL)/lib/libffi.a
 
 
 $(INSTALL)/lib/$(LIB): $(BUILD)/$(LIB) remove_modules.txt
 	( \
 		cd $(BUILD); \
-		sed -i -e 's/libinstall:.*/libinstall:/' Makefile; \
+		sed -i -e 's/libinstall:.*/libinstall:/' $(MAKEFILE_PATCHED); \
 		touch $(BUILD)/$(LIB) ; \
-		emmake make PYTHON_FOR_BUILD=$(HOSTPYTHON) CROSS_COMPILE=yes inclinstall libinstall $(LIB) -j $${PYODIDE_JOBS:-3} && \
+		emmake make PYTHON_FOR_BUILD=$(HOSTPYTHON) CROSS_COMPILE=yes inclinstall libinstall $(LIB) -j $${PYODIDE_JOBS:-3} -f $(MAKEFILE_PATCHED) && \
 		cp $(LIB) $(INSTALL)/lib/ \
 	)
 	# Generate sysconfigdata. It outputs into a subfolder of build/, and
@@ -38,8 +40,6 @@ $(INSTALL)/lib/$(LIB): $(BUILD)/$(LIB) remove_modules.txt
 	cd $(INSTALL)/lib/python$(PYMAJOR).$(PYMINOR)/ && rm -rf `cat $(ROOT)/remove_modules.txt`
 	rm -rf $(PYBUILDDIR)
 	rm pybuilddir.txt
-	cp $(BUILD)/Modules/expat/libexpat.a $(INSTALL)/lib/
-	cp $(BUILD)/Modules/_decimal/libmpdec/libmpdec.a $(INSTALL)/lib/
 
 
 clean:
@@ -103,6 +103,7 @@ $(BUILD)/$(LIB): $(BUILD)/Makefile $(BUILD)/pyconfig.h $(BUILD)/Modules/Setup.lo
 	cp Setup.local $(BUILD)/Modules/
 	( \
 		cd $(BUILD); \
-		emmake make CROSS_COMPILE=yes $(LIB) -j $${PYODIDE_JOBS:-3} \
+		sed '/MODOBJS=/s/$$/ $$(LIBMPDEC_OBJS) $$(LIBEXPAT_OBJS) /' Makefile > $(MAKEFILE_PATCHED); \
+		emmake make CROSS_COMPILE=yes $(LIB) -j $${PYODIDE_JOBS:-3} -f $(MAKEFILE_PATCHED) \
 	)
 	touch $(BUILD)/$(LIB)

--- a/cpython/Makefile
+++ b/cpython/Makefile
@@ -15,17 +15,16 @@ FFIBUILD=$(ROOT)/build/libffi
 LIBFFIREPO=https://github.com/hoodmane/libffi-emscripten
 LIBFFI_TAG=2022-06-23
 
-MAKEFILE_PATCHED=Makefile.patched
-
 all: $(INSTALL)/lib/$(LIB) $(INSTALL)/lib/libffi.a
 
 
 $(INSTALL)/lib/$(LIB): $(BUILD)/$(LIB) remove_modules.txt
 	( \
 		cd $(BUILD); \
-		sed -i -e 's/libinstall:.*/libinstall:/' $(MAKEFILE_PATCHED); \
+		sed -i -e 's/libinstall:.*/libinstall:/' Makefile; \
+		sed -i '/MODOBJS=/s/$$/ $$(LIBMPDEC_OBJS) $$(LIBEXPAT_OBJS) /' Makefile; \
 		touch $(BUILD)/$(LIB) ; \
-		emmake make PYTHON_FOR_BUILD=$(HOSTPYTHON) CROSS_COMPILE=yes inclinstall libinstall $(LIB) -j $${PYODIDE_JOBS:-3} -f $(MAKEFILE_PATCHED) && \
+		emmake make PYTHON_FOR_BUILD=$(HOSTPYTHON) CROSS_COMPILE=yes inclinstall libinstall $(LIB) -j $${PYODIDE_JOBS:-3} && \
 		cp $(LIB) $(INSTALL)/lib/ \
 	)
 	# Generate sysconfigdata. It outputs into a subfolder of build/, and
@@ -103,7 +102,6 @@ $(BUILD)/$(LIB): $(BUILD)/Makefile $(BUILD)/pyconfig.h $(BUILD)/Modules/Setup.lo
 	cp Setup.local $(BUILD)/Modules/
 	( \
 		cd $(BUILD); \
-		sed '/MODOBJS=/s/$$/ $$(LIBMPDEC_OBJS) $$(LIBEXPAT_OBJS) /' Makefile > $(MAKEFILE_PATCHED); \
-		emmake make CROSS_COMPILE=yes $(LIB) -j $${PYODIDE_JOBS:-3} -f $(MAKEFILE_PATCHED) \
+		emmake make CROSS_COMPILE=yes $(LIB) -j $${PYODIDE_JOBS:-3} \
 	)
 	touch $(BUILD)/$(LIB)

--- a/cpython/Makefile
+++ b/cpython/Makefile
@@ -15,12 +15,7 @@ FFIBUILD=$(ROOT)/build/libffi
 LIBFFIREPO=https://github.com/hoodmane/libffi-emscripten
 LIBFFI_TAG=2022-06-23
 
-MPDEC_URL=https://www.bytereef.org/software/mpdecimal/releases/mpdecimal-2.5.1.tar.gz
-MPDEC_TARBALL=$(ROOT)/downloads/mpdec.tgz
-MPDEC_BUILD=$(ROOT)/build/mpdecimal-2.5.1
-MPDEC_INSTALL=$(INSTALL)/lib/libmpdec.a
-
-all: $(INSTALL)/lib/$(LIB) $(INSTALL)/lib/libffi.a $(MPDEC_INSTALL)
+all: $(INSTALL)/lib/$(LIB) $(INSTALL)/lib/libffi.a
 
 
 $(INSTALL)/lib/$(LIB): $(BUILD)/$(LIB) remove_modules.txt
@@ -44,6 +39,7 @@ $(INSTALL)/lib/$(LIB): $(BUILD)/$(LIB) remove_modules.txt
 	rm -rf $(PYBUILDDIR)
 	rm pybuilddir.txt
 	cp $(BUILD)/Modules/expat/libexpat.a $(INSTALL)/lib/
+	cp $(BUILD)/Modules/_decimal/libmpdec/libmpdec.a $(INSTALL)/lib/
 
 
 clean:
@@ -64,16 +60,6 @@ $(BUILD)/.patched: $(TARBALL)
 	[ -d $(BUILD) ] || (mkdir -p $(dir $(BUILD)); tar -C $(dir $(BUILD)) -xf $(TARBALL))
 	cat patches/*.patch | (cd $(BUILD) ; patch -p1)
 	touch $@
-
-$(MPDEC_TARBALL):
-	[ -d $(ROOT)/downloads ] || mkdir $(ROOT)/downloads
-	wget -q -O $@ $(MPDEC_URL)
-
-$(MPDEC_INSTALL) : $(MPDEC_TARBALL)
-	tar -C $(dir $(MPDEC_BUILD)) -xf $(MPDEC_TARBALL)
-	cd $(MPDEC_BUILD) && emconfigure ./configure --disable-shared CFLAGS=-fPIC
-	cd $(MPDEC_BUILD) && emmake make lib
-	cp $(MPDEC_BUILD)/libmpdec/libmpdec.a $@
 
 $(INSTALL)/lib/libffi.a :
 	rm -rf $(FFIBUILD)
@@ -110,7 +96,7 @@ $(BUILD)/Makefile: $(BUILD)/.patched
 	)
 
 
-$(BUILD)/Modules/Setup.local : Setup.local
+$(BUILD)/Modules/Setup.local: Setup.local
 	cp Setup.local $(BUILD)/Modules/
 
 $(BUILD)/$(LIB): $(BUILD)/Makefile $(BUILD)/pyconfig.h $(BUILD)/Modules/Setup.local $(INSTALL)/lib/libffi.a


### PR DESCRIPTION
For some reason, libmpdec and libexpat objects are not linked to libpython by default.

It seems like you managed fixed it by building another local mpdec, then linking it when compiling `pyodide.asm.js`,
but I think it is better to use internal libs and link them to `libpython` directly.

This adds one line: `sed -i '/MODOBJS=/s/$$/ $$(LIBMPDEC_OBJS) $$(LIBEXPAT_OBJS) /' Makefile`
which tells Makefile to pack libmpdec and libexpat objects together when creating libpython3.11.a

