### PR TITLE
Disable _uuid

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -156,7 +156,7 @@ jobs:
       fail-fast: false
       matrix:
         runner: [playwright]
-        browser: [firefox, chrome]
+        browser: [chrome]
 
     steps:
       - uses: actions/checkout@v2
@@ -178,8 +178,7 @@ jobs:
         run: |
           pip install -r requirements.txt
           pip install -e ./pyodide-build
-          # FIXME: playwright 1.23.0 has unknown performance issue on firefox
-          pip install "playwright<1.23.0" && python -m playwright install
+          python -m playwright install
 
       - name: run core tests
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 concurrency:
   group: main-${{ github.head_ref }}

--- a/cpython/Setup.local
+++ b/cpython/Setup.local
@@ -23,3 +23,4 @@ _sqlite3
 _ssl
 _lzma
 _hashlib
+_uuid


### PR DESCRIPTION
This disables `_uuid` module manually.

Note that `_uuid` wasn't included in Pyodide before.
But it seems like `configure` now detects local libuuid (linux elf) and enable _uuid when it finds it.

Related upstream change: https://github.com/python/cpython/pull/29353

